### PR TITLE
External config file for email and proxy settings

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -7,6 +7,7 @@ import numpy as np
 import concurrent.futures
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail, Email, To, Content, HtmlContent
+import json
 import schedule
 import time
 import random
@@ -26,12 +27,21 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Chargement de la configuration externe
+CONFIG_FILE = 'config.json'
+try:
+    with open(CONFIG_FILE, 'r') as f:
+        cfg = json.load(f)
+except Exception as e:
+    logger.error(f"Erreur lors du chargement du fichier de configuration: {e}")
+    cfg = {}
+
 # Liste de proxies HTTP pour contourner d'éventuels blocages
-PROXIES = [
+PROXIES = cfg.get('PROXIES', [
     "http://proxy1.example.com:8080",
     "http://proxy2.example.com:8080",
     "http://proxy3.example.com:8080",
-]
+])
 
 
 def set_random_proxy():
@@ -42,9 +52,9 @@ def set_random_proxy():
     return proxy
 
 # Configuration SendGrid et emails
-SENDGRID_API_KEY = 'xxx'
-FROM_EMAIL = "xxx"
-TO_EMAIL = "xxx"
+SENDGRID_API_KEY = cfg.get('SENDGRID_API_KEY', 'xxx')
+FROM_EMAIL = cfg.get('FROM_EMAIL', 'xxx')
+TO_EMAIL = cfg.get('TO_EMAIL', 'xxx')
 
 class IndicateursBoursiers:
     @staticmethod

--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+  "PROXIES": [
+    "http://proxy1.example.com:8080",
+    "http://proxy2.example.com:8080",
+    "http://proxy3.example.com:8080"
+  ],
+  "SENDGRID_API_KEY": "xxx",
+  "FROM_EMAIL": "xxx",
+  "TO_EMAIL": "xxx"
+}


### PR DESCRIPTION
## Summary
- load configuration from `config.json`
- move proxy list and SendGrid/email settings to that file

## Testing
- `python -m py_compile analyzer.py template_mail.py`

------
https://chatgpt.com/codex/tasks/task_e_684381daa3d483219d921f9086e13582