### PR TITLE
Add shared proxy setup to analyse_portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ pip install pandas numpy yfinance sendgrid schedule pyyaml
 - **`analyzer.py`** : recherche des opportunités d'achat sur plusieurs places boursières européennes puis envoie un résumé par e‑mail.
 - **`daily_update.py`** : met à jour automatiquement le dépôt (pull Git) puis lance `analyse_portfolio.py` et `analyzer.py`.
 - **`template_mail.py`** : contient le modèle HTML utilisé pour formater les e‑mails.
-- **`config.yaml`** : configuration du portefeuille et informations d'envoi pour `analyse_portfolio.py`.
+- **`config.yaml`** : configuration du portefeuille, des proxies et informations d'envoi pour `analyse_portfolio.py`.
 - **`config.json`** : configuration générale (proxies, clé SendGrid, adresses e‑mail) utilisée par `analyzer.py`.
 
 ## Utilisation des scripts
 
 1. **Configurer les fichiers de configuration**
-   - Remplir `config.yaml` avec vos actions, votre clé SendGrid et les adresses e‑mail expéditrice/destinataire.
+   - Remplir `config.yaml` avec vos actions, vos proxies éventuels, votre clé SendGrid et les adresses e‑mail expéditrice/destinataire.
    - Mettre à jour `config.json` avec votre clé SendGrid (si différente), vos proxies éventuels et les adresses e‑mail.
 
 2. **Lancer l'analyse du portefeuille**

--- a/analyse_portfolio.py
+++ b/analyse_portfolio.py
@@ -4,6 +4,32 @@ import yfinance as yf
 from datetime import datetime, timedelta
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
+import os
+import random
+
+# Chargement de la configuration globale et des proxies
+CONFIG_FILE = 'config.yaml'
+try:
+    with open(CONFIG_FILE, 'r') as f:
+        CFG = yaml.safe_load(f)
+except Exception as e:
+    print(f"Erreur lors du chargement du fichier de configuration: {e}")
+    CFG = {}
+
+# Liste de proxies HTTP similaire à celle utilisée dans analyzer.py
+PROXIES = CFG.get('proxies', [
+    "http://proxy1.example.com:8080",
+    "http://proxy2.example.com:8080",
+    "http://proxy3.example.com:8080",
+])
+
+
+def set_random_proxy():
+    """Choisit un proxy aléatoirement et le définit pour les requêtes."""
+    proxy = random.choice(PROXIES)
+    os.environ["HTTP_PROXY"] = proxy
+    os.environ["HTTPS_PROXY"] = proxy
+    return proxy
 
 class PortfolioUtils:
     @staticmethod
@@ -37,6 +63,8 @@ class PortfolioAnalyzer:
     def get_stock_analysis(self, symbol, purchase_info, periods):
         """Analyse une action et retourne ses variations sur différentes périodes."""
         try:
+            proxy = set_random_proxy()
+            print(f"Proxy utilisé pour {symbol}: {proxy}")
             stock = yf.Ticker(symbol)
             end_date = datetime.now()
 


### PR DESCRIPTION
## Summary
- load `config.yaml` at module level in `analyse_portfolio.py`
- define `PROXIES` and `set_random_proxy()` similar to `analyzer.py`
- use `set_random_proxy()` before each stock request

## Testing
- `python -m py_compile analyse_portfolio.py`
- `python -m py_compile analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_68438e60efe48321bac233965c5852c1