### PR TITLE
Add switch to disable proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ pip install pandas numpy yfinance sendgrid schedule pyyaml
 - **`analyzer.py`** : recherche des opportunités d'achat sur plusieurs places boursières européennes puis envoie un résumé par e‑mail.
 - **`daily_update.py`** : met à jour automatiquement le dépôt (pull Git) puis lance `analyse_portfolio.py` et `analyzer.py`.
 - **`template_mail.py`** : contient le modèle HTML utilisé pour formater les e‑mails.
-- **`config.yaml`** : configuration du portefeuille, des proxies et informations d'envoi pour `analyse_portfolio.py`.
+- **`config.yaml`** : configuration du portefeuille, des proxies et informations d'envoi pour `analyse_portfolio.py`. Le fichier contient également un paramètre `use_proxies` permettant de désactiver totalement leur utilisation.
 - **`config.json`** : configuration générale (proxies, clé SendGrid, adresses e‑mail) utilisée par `analyzer.py`.
 
 ## Utilisation des scripts
 
 1. **Configurer les fichiers de configuration**
-   - Remplir `config.yaml` avec vos actions, vos proxies éventuels, votre clé SendGrid et les adresses e‑mail expéditrice/destinataire.
+   - Remplir `config.yaml` avec vos actions, votre clé SendGrid et les adresses e‑mail expéditrice/destinataire. Vous pouvez renseigner une liste de proxies et définir `use_proxies: false` pour les désactiver.
    - Mettre à jour `config.json` avec votre clé SendGrid (si différente), vos proxies éventuels et les adresses e‑mail.
 
 2. **Lancer l'analyse du portefeuille**

--- a/analyse_portfolio.py
+++ b/analyse_portfolio.py
@@ -22,10 +22,18 @@ PROXIES = CFG.get('proxies', [
     "http://proxy2.example.com:8080",
     "http://proxy3.example.com:8080",
 ])
+# Possibilité de désactiver complètement l'utilisation des proxies
+USE_PROXIES = CFG.get('use_proxies', True)
 
 
 def set_random_proxy():
     """Choisit un proxy aléatoirement et le définit pour les requêtes."""
+    if not USE_PROXIES:
+        # Nettoyer les éventuelles variables d'environnement
+        os.environ.pop("HTTP_PROXY", None)
+        os.environ.pop("HTTPS_PROXY", None)
+        return None
+
     proxy = random.choice(PROXIES)
     os.environ["HTTP_PROXY"] = proxy
     os.environ["HTTPS_PROXY"] = proxy
@@ -64,7 +72,8 @@ class PortfolioAnalyzer:
         """Analyse une action et retourne ses variations sur différentes périodes."""
         try:
             proxy = set_random_proxy()
-            print(f"Proxy utilisé pour {symbol}: {proxy}")
+            if proxy:
+                print(f"Proxy utilisé pour {symbol}: {proxy}")
             stock = yf.Ticker(symbol)
             end_date = datetime.now()
 

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,9 @@ email:
   to: "xxx"
   api_key: "xxx"
 
+# Active ou désactive l'utilisation des proxies HTTP
+use_proxies: true
+
 proxies:
   - "http://proxy1.example.com:8080"
   - "http://proxy2.example.com:8080"


### PR DESCRIPTION
## Summary
- allow proxy usage to be toggled via `use_proxies` in config
- disable proxies in code when `use_proxies` is false
- document the new configuration option

## Testing
- `python -m py_compile analyse_portfolio.py analyzer.py daily_update.py template_mail.py`

------
https://chatgpt.com/codex/tasks/task_e_684446591698832189b9321a221cb06c