### PR TITLE
Fix yfinance rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Ce projet contient plusieurs scripts Python permettant d'analyser des actions eu
   - `pandas`
   - `numpy`
   - `yfinance`
+  - `curl_cffi`  # pour contourner les limitations d'accès de Yahoo Finance
   - `sendgrid`
   - `schedule`
   - `pyyaml`
@@ -16,7 +17,7 @@ Ce projet contient plusieurs scripts Python permettant d'analyser des actions eu
 Installation rapide :
 
 ```bash
-pip install pandas numpy yfinance sendgrid schedule pyyaml
+pip install pandas numpy yfinance curl_cffi sendgrid schedule pyyaml
 ```
 
 ## Structure du projet
@@ -59,4 +60,6 @@ Cette dernière commande mettra à jour le dépôt depuis son origine puis exéc
 - `template_mail.py` est une librairie et n'est pas destiné à être exécuté directement.
 - Les logs des différents scripts sont généralement enregistrés dans des fichiers `.log` ou affichés sur la sortie standard pour faciliter le débogage.
 - Pensez à créer une tâche planifiée (cron ou autre) si vous souhaitez automatiser l'exécution quotidienne de `daily_update.py`.
+- En cas de problèmes de rate limit avec Yahoo Finance, le code utilise désormais
+  `curl_cffi` pour ouvrir une session qui imite un navigateur Chrome.
 

--- a/analyzer.py
+++ b/analyzer.py
@@ -13,8 +13,9 @@ from datetime import datetime
 import logging
 import sys
 from template_mail import RapportHTML
-import requests
-from requests.adapters import HTTPAdapter
+# Utilisation de curl_cffi pour contourner les limitations de Yahoo Finance
+# cf. https://github.com/ranaroussi/yfinance/issues/2422#issuecomment-2840774505
+from curl_cffi import requests
 
 # Configuration du logging
 logging.basicConfig(
@@ -45,11 +46,8 @@ PROXIES = cfg.get('proxies', [
 # Possibilité de désactiver complètement l'utilisation des proxies
 USE_PROXIES = cfg.get('use_proxies', True)
 
-# Session HTTP global avec pool plus large pour yfinance
-SESSION = requests.Session()
-adapter = HTTPAdapter(pool_connections=50, pool_maxsize=50)
-SESSION.mount("http://", adapter)
-SESSION.mount("https://", adapter)
+# Session HTTP global impersonant Chrome pour contourner les blocages
+SESSION = requests.Session(impersonate="chrome")
 
 
 def set_random_proxy():


### PR DESCRIPTION
## Summary
- switch requests to `curl_cffi` for yfinance
- share a Chrome-impersonating Session across requests
- document new `curl_cffi` dependency and usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68444f42bbe483218a0634f5809a051b