### PR TITLE
Fix duplicate portfolio analysis

### DIFF
--- a/daily_update.py
+++ b/daily_update.py
@@ -44,17 +44,31 @@ def update_repo():
         subprocess.run(['git', '-C', REPO_DIR, 'pull'], check=True)
     _restore_config(backup)
 
+_portfolio_ran = False
+
+
 def run_portfolio_report():
-    """Run the daily portfolio report if available."""
+    """Run the daily portfolio report exactly once."""
+    global _portfolio_ran
+    if _portfolio_ran:
+        logging.info('Portfolio report already executed; skipping.')
+        return
+
     try:
         sys.path.insert(0, REPO_DIR)
         module = importlib.import_module('analyse_portfolio')
+
         if hasattr(module, 'rapport_quotidien'):
             module.rapport_quotidien()
         elif hasattr(module, 'main'):
             module.main()
         else:
-            subprocess.run(['python', os.path.join(REPO_DIR, 'analyse_portfolio.py')], check=True)
+            subprocess.run([
+                'python',
+                os.path.join(REPO_DIR, 'analyse_portfolio.py')
+            ], check=True)
+
+        _portfolio_ran = True
     except ModuleNotFoundError:
         logging.warning('Module analyse_portfolio not found; skipping portfolio report.')
     except Exception as exc:


### PR DESCRIPTION
## Summary
- ensure `run_portfolio_report()` runs only once using a guard flag

## Testing
- `python -m py_compile daily_update.py`
- `REPO_DIR=/workspace/StockAnalyzer python daily_update.py` *(fails: no tracking info for branch)*

------
https://chatgpt.com/codex/tasks/task_e_684945d592988321b9dcf8a2b73d25ba