### PR TITLE
Make thresholds configurable via YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ pip install pandas numpy yfinance curl_cffi sendgrid schedule pyyaml
 - **`analyzer.py`** : recherche des opportunités d'achat sur plusieurs places boursières européennes puis envoie un résumé par e‑mail.
 - **`daily_update.py`** : met à jour automatiquement le dépôt (pull Git) puis lance `analyse_portfolio.py` et `analyzer.py`.
 - **`template_mail.py`** : contient le modèle HTML utilisé pour formater les e‑mails.
-- **`config.yaml`** : configuration du portefeuille, des proxies et informations d'envoi pour `analyse_portfolio.py`. Le fichier contient également un paramètre `use_proxies` permettant de désactiver totalement leur utilisation.
+- **`config.yaml`** : configuration du portefeuille, des proxies et informations d'envoi pour `analyse_portfolio.py`. Le fichier contient également un paramètre `use_proxies` pour désactiver les proxies et une section `thresholds` afin d'ajuster les seuils techniques utilisés par `analyzer.py`.
 - **`config.json`** : configuration générale (proxies, clé SendGrid, adresses e‑mail) utilisée par `analyzer.py`.
 
 ## Utilisation des scripts
 
 1. **Configurer les fichiers de configuration**
-   - Remplir `config.yaml` avec vos actions, votre clé SendGrid et les adresses e‑mail expéditrice/destinataire. Vous pouvez renseigner une liste de proxies et définir `use_proxies: false` pour les désactiver.
+   - Remplir `config.yaml` avec vos actions, votre clé SendGrid et les adresses e‑mail expéditrice/destinataire. Vous pouvez renseigner une liste de proxies et définir `use_proxies: false` pour les désactiver. La section `thresholds` permet de modifier les bornes du RSI, la marge autour des moyennes mobiles ou encore le score minimal retenu par `analyzer.py`.
    - Mettre à jour `config.json` avec votre clé SendGrid (si différente), vos proxies éventuels et les adresses e‑mail.
 
 2. **Lancer l'analyse du portefeuille**

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,15 @@ proxies:
   - "http://proxy2.example.com:8080"
   - "http://proxy3.example.com:8080"
 
+# Seuils utilisés par analyzer.py
+thresholds:
+  rsi_lower: 30
+  rsi_upper: 70
+  mm_neutral_ratio: 0.02
+  bollinger_threshold: 0.05
+  peg_max: 1
+  min_opportunity_score: 0.5
+
 portfolio:
   - symbol: "ELIOR.PA"
     name: "Elior"


### PR DESCRIPTION
## Summary
- add threshold values in `config.yaml`
- read threshold configuration in `analyzer.py`
- use configured values for RSI bounds, Bollinger band check, PEG limit, and minimum score
- document the new parameters in `README.md`

## Testing
- `python -m py_compile analyzer.py analyse_portfolio.py daily_update.py template_mail.py proxy_tester.py yfinance_cookie_patch.py`

------
https://chatgpt.com/codex/tasks/task_e_68710d7cac3883219d78c6fca64cd47b