### PR TITLE
Fix backtest buying logic

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,8 @@ signal_weights:
 
 # Pourcentage de perte acceptable pour le calcul du stop loss
 stop_loss_percent: 5
+# Pourcentage de gain recherché pour sortir d'une position
+profit_target_percent: 10
 
 portfolio:
   - symbol: "ELIOR.PA"


### PR DESCRIPTION
## Summary
- add a `profit_target_percent` setting in `config.yaml`
- load the configuration in `backtest.py`
- overhaul the buy/sell logic in `backtest.py` to select the best opportunities and exit positions when targets are hit

## Testing
- `python -m py_compile backtest.py analyzer.py analyse_portfolio.py daily_update.py cache_utils.py template_mail.py proxy_tester.py yfinance_cookie_patch.py`
- `python backtest.py --cash 10000` *(fails: network access to fc.yahoo.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6880eb90c3dc8321bf86d0116cf1d54b