### PR TITLE
Add CLI script for single stock evaluation

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -732,7 +732,8 @@ class AnalyseAction:
                     for k, v in signaux.items()
                     if v and SIGNAL_WEIGHTS.get(k, 1.0) > 0
                 ]
-            )
+            ),
+            'indicateurs': {k: bool(v) for k, v in signaux.items()},
         }
 
     def _calculer_position_bollinger(self, prix, bande_inf, bande_sup):

--- a/evaluate_stock.py
+++ b/evaluate_stock.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Lance l'analyse d'une action passée en argument et affiche le détail des indicateurs."""
+
+import sys
+import analyzer
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python evaluate_stock.py <TICKER>")
+        sys.exit(1)
+
+    ticker = sys.argv[1]
+
+    # Désactiver l'utilisation des proxies pour une exécution simple
+    analyzer.USE_PROXIES = False
+
+    analyse = analyzer.AnalyseAction(ticker)
+    resultat = analyse.analyser()
+
+    if resultat is None:
+        print(f"Analyse impossible pour {ticker}")
+        sys.exit(1)
+
+    # Affichage structuré des résultats
+    print(f"Résultats pour {ticker}:")
+    for cle, valeur in resultat.items():
+        if cle == "indicateurs":
+            print("Indicateurs:")
+            for nom, val in valeur.items():
+                print(f"  - {nom}: {val}")
+        else:
+            print(f"{cle}: {val}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose individual indicator results from `AnalyseAction`
- add `evaluate_stock.py` script to run analysis for a ticker and display indicator details

## Testing
- `python evaluate_stock.py AAPL` *(fails: Could not connect to server)*
- `python -m py_compile evaluate_stock.py analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_68b43b211c748321810b7526073b0fa9