### PR TITLE
Corrige la regression causée par les indicateurs sans poids

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -733,7 +733,11 @@ class AnalyseAction:
                     if v and SIGNAL_WEIGHTS.get(k, 1.0) > 0
                 ]
             ),
-            'indicateurs': {k: bool(v) for k, v in signaux.items()},
+            'indicateurs': {
+                k: bool(v)
+                for k, v in signaux.items()
+                if SIGNAL_WEIGHTS.get(k, 1.0) > 0
+            },
         }
 
     def _calculer_position_bollinger(self, prix, bande_inf, bande_sup):


### PR DESCRIPTION
## Résumé
- Filtre les indicateurs sans poids lors du formatage des résultats.

## Tests
- `python -m py_compile analyzer.py evaluate_stock.py`


------
https://chatgpt.com/codex/tasks/task_e_68b602d79f788321a68fbba8ad1cc290